### PR TITLE
Variables provided as defaults need !default flag

### DIFF
--- a/starability-scss/_variables.scss
+++ b/starability-scss/_variables.scss
@@ -1,10 +1,10 @@
-$star-count: 5;
-$star-size: 30px;
+$star-count: 5 !default;
+$star-size: 30px !default;
 
-$image-directory-path: '../starability-images';
+$image-directory-path: '../starability-images' !default;
 
 // if true there is an underline below active star
-$accessible-highlight: true;
+$accessible-highlight: true !default;
 
 // if true, stars are highlighted on hover (causes website repaints)
-$hover-enabled: true;
+$hover-enabled: true !default;


### PR DESCRIPTION
Allows users to override the variables ahead of importing your scss.

Note you may also want to consider more unique names for these – particularly `$image-directory-path`,  `$accessible-highlight` and `$hover-enabled` – e.g. prefixing with `starability` or `star` –  `$star-count` `$star-size` are probably fine.