### PR TITLE
Navigating the stars with left/right arrows is no longer reversed

### DIFF
--- a/starability-scss/_starability-base.scss
+++ b/starability-scss/_starability-base.scss
@@ -8,43 +8,62 @@
   padding: 0;
   border: none;
 
-  > input {
-    position: absolute;
-    margin-right: -100%;
-    opacity: 0;
-  }
+  > {
+    input {
+      position: absolute;
+      margin-left: -100%;
+      opacity: 0;
 
-  > input:checked ~ label,
-  > input:focus ~ label {
-    background-position: 0 (-$star-size);
+      &:first-of-type + label {
+        position: absolute;
+        margin-left: -100%;
+        opacity: 0;
+      }
+
+      &:checked, &:focus {
+        ~ label { background-position: 0 0; }
+        + label { background-position: 0 (-$star-size); }
+      }
+
+      @if ($accessible-highlight) {
+        &:first-of-type:checked:focus {
+          ~ label { outline: 1px dotted #999; }
+        }
+        &:focus {
+          + label { outline: 1px dotted #999; }
+        }
+      }
+    }
+
+    label {
+      position: relative;
+      display: inline-block;
+      float: left;
+      width: $star-size;
+      height: $star-size;
+      color: transparent;
+      cursor: pointer;
+      background-image: url('#{$image-directory-path}/#{$bg-image-path}.png');
+      background-position: 0 (-$star-size);
+      background-repeat: no-repeat;
+
+      @media screen and (min-resolution: 192dpi) {
+        background-image: url('#{$image-directory-path}/#{$bg-image-path}@2x.png');
+        background-size: $star-size auto;
+      }
+    }
   }
 
   @if ($hover-enabled) {
-    > input:hover ~ label {
-      background-position: 0 (-$star-size);
-    }
-  }
+    &:hover {
+      > {
+        label { background-position: 0 (-$star-size) !important; }
 
-  @if ($accessible-highlight) {
-    > input:focus + label {
-      outline: 1px dotted #999;
-    }
-  }
-
-  > label {
-    position: relative;
-    display: inline-block;
-    float: right;
-    width: $star-size;
-    height: $star-size;
-    color: transparent;
-    cursor: pointer;
-    background-image: url('#{$image-directory-path}/#{$bg-image-path}.png');
-    background-repeat: no-repeat;
-
-    @media screen and (min-resolution: 192dpi) {
-      background-image: url('#{$image-directory-path}/#{$bg-image-path}@2x.png');
-      background-size: $star-size auto;
+        input:hover {
+          ~ label { background-position: 0 0 !important; }
+          + label { background-position: 0 (-$star-size) !important; }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I wanted to experiment with getting the left/right arrows working in the right order – I don't know if you can merge this given backwards compatibility issues and the addition of a zero rating option – but this seems to work quite well with the following (addition of a zero rating).

```
<fieldset class="starability-basic">
  <legend>First rating:</legend>
  <input type="radio" id="first-rate0" name="rating" value="0" checked>
  <label for="first-rate0" title="Terrible">0 star</label>
  <input type="radio" id="first-rate1" name="rating" value="1">
  <label for="first-rate1" title="Terrible">1 star</label>
  <input type="radio" id="first-rate2" name="rating" value="2">
  <label for="first-rate2" title="Not good">2 stars</label>
  <input type="radio" id="first-rate3" name="rating" value="3">
  <label for="first-rate3" title="Average">3 stars</label>
  <input type="radio" id="first-rate4" name="rating" value="4">
  <label for="first-rate4" title="Very good">4 stars</label>
  <input type="radio" id="first-rate5" name="rating" value="5">
  <label for="first-rate5" title="Amazing">5 stars</label>
</fieldset>
```

Note that the zero rating needs to be checked by default – without the zero rating selection the widget appears as if 5 stars when really nothing is checked.

When the zero rating is checked I've adjusted the CSS to outline all of the ratings so that users can see they have focused the widget – I'd prefer it to have a single outline around the widget but this is easier.