### PR TITLE
Revise static result example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you have a different file structure, remember to update file path for CSS sty
     </fieldset>
     ```
 
-2. Add a stylesheet with a name of an animation that works best for your app name inside your website's <head> element. There are [the minified versions](https://github.com/LunarLogic/starability/tree/master/starability-minified) or [standard CSS files](https://github.com/LunarLogic/starability/tree/master/starability-css). Let's say we want a fading animation:
+2. Add a stylesheet with a name of an animation that works best for your app name inside your website's `<head>` element. There are [the minified versions](https://github.com/LunarLogic/starability/tree/master/starability-minified) or [standard CSS files](https://github.com/LunarLogic/starability/tree/master/starability-css). Let's say we want a fading animation:
 
     ```html
     <head>
@@ -112,10 +112,10 @@ This rating system by default reacts to `:hover`, changing the background image 
 You can add the static results of the rating anywhere you need it. To indicate how many stars were added, change the `data-rating` value on an element with the `starability-result` class. Please note, that this supports only integer numbers. If you wish to show the results as the float numbers, you might need to use other solution.
 
 ```html
-  <p id="rated-element">Rated element name</p>
-  <div class="starability-result" data-rating="3" aria-describedby="rated-element">
-    3 stars
-  </div>
+  <p>Rated element name</p>
+  <p class="starability-result" data-rating="3">
+    Rated: 3 stars
+  </p>
 ```
 
 ## Further customisation with SASS

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This rating system by default reacts to `:hover`, changing the background image 
 You can add the static results of the rating anywhere you need it. To indicate how many stars were added, change the `data-rating` value on an element with the `starability-result` class. Please note, that this supports only integer numbers. If you wish to show the results as the float numbers, you might need to use other solution.
 
 ```html
-  <p>Rated element name</p>
+  <h3>Rated element name</h3>
   <p class="starability-result" data-rating="3">
     Rated: 3 stars
   </p>

--- a/index.html
+++ b/index.html
@@ -34,9 +34,10 @@
   </form>
   <h2>Static result example</h2>
   <!-- The result is based on the 'data-rating' value. Change the value to see the different static rating. -->
-  <p id="result1">Movie name</p>
-  <div class="starability-result" data-rating="3" aria-describedby="result1">
-    3 stars
-  </div>
+  <h3>Movie name</h3>
+  <p>Information about the movie...</p>
+  <p class="starability-result" data-rating="3">
+    Rated: 3 stars
+  </p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@
   <h2>Static result example</h2>
   <!-- The result is based on the 'data-rating' value. Change the value to see the different static rating. -->
   <h3>Movie name</h3>
-  <p>Information about the movie...</p>
   <p class="starability-result" data-rating="3">
     Rated: 3 stars
   </p>


### PR DESCRIPTION
Using `aria-describedby` on elements like `<div>` or `<p>` is not broadly supported in screen readers.

VoiceOver and NVDA do not recognize the connection when a non-form field, button, link or landmark use `aria-describeby` to point to another element.

JAWS does reveal the connection, but requires a user to press <kbd>JAWS key + ALT + R</kbd> to read the descriptive text. (JAWS auto-reads descriptive text when used on one of the mentioned supported elements).

As the example isn’t well supported, and isn’t truly necessary if a  document is setup appropriately, the revised pattern changes the movie name text to be within an `<h3>`, adds a line of dummy info text, and places the rating to be within a `<p>`, with additional “Rated:” text to provide context for why someone would be hearing “3 stars”.

Let me know if there's any questions about this PR, or if there's anything else you'd like to see done with the updated example.

Thanks!