### PR TITLE
Fix/remove inline block

### DIFF
--- a/starability-css/starability-all.css
+++ b/starability-css/starability-all.css
@@ -108,7 +108,6 @@
 
 .starability-basic > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -299,7 +298,6 @@
 
 .starability-slot > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -532,7 +530,6 @@
 
 .starability-grow > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -788,7 +785,6 @@
 
 .starability-growRotate > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -1040,7 +1036,6 @@
 
 .starability-fade > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -1301,7 +1296,6 @@
 
 .starability-checkmark > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -1607,7 +1601,6 @@
 
 .starability-heart > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -1889,7 +1882,6 @@
 
 .starability-heartbeat > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;
@@ -2191,7 +2183,6 @@
 
 .starability-coinFlip > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-basic.css
+++ b/starability-css/starability-basic.css
@@ -108,7 +108,6 @@
 
 .starability-basic > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-checkmark.css
+++ b/starability-css/starability-checkmark.css
@@ -148,7 +148,6 @@
 
 .starability-checkmark > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-coinFlip.css
+++ b/starability-css/starability-coinFlip.css
@@ -187,7 +187,6 @@
 
 .starability-coinFlip > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-fade.css
+++ b/starability-css/starability-fade.css
@@ -139,7 +139,6 @@
 
 .starability-fade > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-grow.css
+++ b/starability-css/starability-grow.css
@@ -143,7 +143,6 @@
 
 .starability-grow > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-growRotate.css
+++ b/starability-css/starability-growRotate.css
@@ -143,7 +143,6 @@
 
 .starability-growRotate > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-heart.css
+++ b/starability-css/starability-heart.css
@@ -171,7 +171,6 @@
 
 .starability-heart > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-heartbeat.css
+++ b/starability-css/starability-heartbeat.css
@@ -169,7 +169,6 @@
 
 .starability-heartbeat > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-rotate.css
+++ b/starability-css/starability-rotate.css
@@ -83,7 +83,6 @@
 
 .starability-heart > label {
   position: relative;
-  display: inline-block;
   float: right;
   width: 30px;
   height: 30px;

--- a/starability-css/starability-slot.css
+++ b/starability-css/starability-slot.css
@@ -108,7 +108,6 @@
 
 .starability-slot > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;

--- a/starability-scss/_starability-base.scss
+++ b/starability-scss/_starability-base.scss
@@ -66,7 +66,6 @@
 
   > label {
     position: relative;
-    display: inline-block;
     float: left;
     width: $star-size;
     height: $star-size;


### PR DESCRIPTION
### **Fix: Remove redundant inline-block on floated labels**

1. **Summary**: Removed the display: inline-block property from the > label selector.
2. **Background/Issue**:  In our CSS, the labels have both display: inline-block and float: left. Since applying a float automatically converts an element's display to block, the inline-block value is redundant and can lead to warnings or confusion.
3. **Why This Change Is Important:** By removing the redundant property, the CSS is cleaner, more maintainable, and avoids any unexpected behavior in different browsers or environments.
4. **Testing**: Tested in multiple browsers to ensure that the layout of the star rating widget remains consistent and behaves as expected.
5. **Additional Notes (Optional)**: This fix could help prevent CSS warnings and better align with best practices. See [MDN on float](https://developer.mozilla.org/en-US/docs/Web/CSS/float) for more details on how floats affect the display property.