### PR TITLE
Change float property to none for coinFlip label

### DIFF
--- a/starability-css/starability-coinFlip.css
+++ b/starability-css/starability-coinFlip.css
@@ -188,7 +188,7 @@
 .starability-coinFlip > label {
   position: relative;
   display: inline-block;
-  float: left;
+  float: none;
   width: 30px;
   height: 30px;
   font-size: 0.1em;


### PR DESCRIPTION
inline-block is ignoroed due to the float. If 'float' has a value other than 'none', the box is floated and 'display' is treated as 'block'