### PR TITLE
Remove display inline-block from coinFlip label

### DIFF
--- a/starability-css/starability-coinFlip.css
+++ b/starability-css/starability-coinFlip.css
@@ -187,7 +187,6 @@
 
 .starability-coinFlip > label {
   position: relative;
-  display: inline-block;
   float: left;
   width: 30px;
   height: 30px;


### PR DESCRIPTION
Removed display inline-block from label in coinFlip CSS. “inline-block is ignored due to float. If float is not none, the box is floated and display is treated as block.”